### PR TITLE
WWWS7E-45 Lazy Load Pictures in Slick

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1568,6 +1568,19 @@
                                 }
                             }
 
+                            var pictureSources = image.siblings('source');
+                            if (pictureSources.length) {
+                                pictureSources.each(function () {
+                                    var source = $(this);
+                                    var pictureSrcSet = source.attr('data-srcset');
+                                    if (pictureSrcSet) {
+                                        source
+                                            .attr('srcset', pictureSrcSet )
+                                            .removeAttr('data-srcset');
+                                    }
+                                });
+                            }
+                            
                             image
                                 .attr('src', imageSource)
                                 .animate({ opacity: 1 }, 200, function() {
@@ -1789,6 +1802,19 @@
                         image
                             .attr('sizes', imageSizes );
                     }
+                }
+
+                var pictureSources = image.siblings('source');
+                if (pictureSources.length) {
+                    pictureSources.each(function () {
+                        var source = $(this);
+                        var pictureSrcSet = source.attr('data-srcset');
+                        if (pictureSrcSet) {
+                            source
+                                .attr('srcset', pictureSrcSet )
+                                .removeAttr('data-srcset');
+                        }
+                    });
                 }
 
                 image


### PR DESCRIPTION
In order to lazy load picture elements, both the img src attribute and any source srcset attributes have to be transformed from data attributes. This update adds a transform for data-srcset on any source elements so that picture elements properly lazy load and with the appropriate formats.